### PR TITLE
Fix  download ptb warning

### DIFF
--- a/tools/download_calib_dataset.py
+++ b/tools/download_calib_dataset.py
@@ -29,7 +29,7 @@ def download(calib_dataset_name, path):
         calib_dataset.save_to_disk(save_path)
         logger.info("download wikitext2 for calib finished.")
     if "ptb" in calib_dataset_name:
-        calib_dataset = load_dataset("ptb_text_only", "penn_treebank", split="train")
+        calib_dataset = load_dataset("ptb_text_only", "penn_treebank", split="train", trust_remote_code=True)
         save_path = os.path.join(path, "ptb")
         calib_dataset.save_to_disk(save_path)
         logger.info("download ptb for calib finished.")

--- a/tools/download_eval_dataset.py
+++ b/tools/download_eval_dataset.py
@@ -24,7 +24,7 @@ def download(calib_dataset_name, path):
         calib_dataset.save_to_disk(save_path)
         logger.info("download wikitext2 for eval finished.")
     if "ptb" in calib_dataset_name:
-        calib_dataset = load_dataset("ptb_text_only", "penn_treebank", split="test")
+        calib_dataset = load_dataset("ptb_text_only", "penn_treebank", split="test", trust_remote_code=True)
         save_path = os.path.join(path, "ptb")
         calib_dataset.save_to_disk(save_path)
         logger.info("download ptb for eval finished.")


### PR DESCRIPTION
```
The repository for ptb_text_only contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/ptb_text_only.
You can avoid this prompt in future by passing the argument `trust_remote_code=True`.

Do you wish to run the custom code? [y/N] Traceback (most recent call last):
  File "/home/chris/go/src/gitlab.sz.sensetime.com/archer/inference/llmc/tools/download_calib_dataset.py", line 49, in <module>
```