### PR TITLE
fix: ensure only rank 0 process creates output directories

### DIFF
--- a/llmc/__main__.py
+++ b/llmc/__main__.py
@@ -9,7 +9,7 @@ import torch
 import yaml
 from easydict import EasyDict
 from loguru import logger
-from torch.distributed import destroy_process_group, init_process_group, barrier
+from torch.distributed import destroy_process_group, init_process_group
 
 from llmc.compression.quantization import *
 from llmc.compression.sparsification import *

--- a/llmc/__main__.py
+++ b/llmc/__main__.py
@@ -9,7 +9,7 @@ import torch
 import yaml
 from easydict import EasyDict
 from loguru import logger
-from torch.distributed import destroy_process_group, init_process_group
+from torch.distributed import destroy_process_group, init_process_group, barrier
 
 from llmc.compression.quantization import *
 from llmc.compression.sparsification import *
@@ -238,35 +238,39 @@ if __name__ == '__main__':
 
     seed_all(config.base.seed + int(os.environ['RANK']))
 
-    # mkdirs
-    if 'save' in config:
-        if config.save.get('save_trans', False):
-            save_trans_path = os.path.join(config.save.save_path, 'transformed_model')
-            mkdirs(save_trans_path)
-        if config.save.get('save_trtllm', False):
-            save_trtllm_trans_path = os.path.join(
-                config.save.save_path, 'trtllm_transformed_model'
-            )
-            mkdirs(save_trtllm_trans_path)
-            save_trtllm_engine_path = os.path.join(
-                config.save.save_path, 'trtllm_engine'
-            )
-            mkdirs(save_trtllm_engine_path)
-        if config.save.get('save_vllm', False):
-            save_quant_path = os.path.join(config.save.save_path, 'vllm_quant_model')
-            mkdirs(save_quant_path)
-        if config.save.get('save_sgl', False):
-            save_quant_path = os.path.join(config.save.save_path, 'sgl_quant_model')
-            mkdirs(save_quant_path)
-        if config.save.get('save_autoawq', False):
-            save_quant_path = os.path.join(config.save.save_path, 'autoawq_quant_model')
-            mkdirs(save_quant_path)
-        if config.save.get('save_mlcllm', False):
-            save_quant_path = os.path.join(config.save.save_path, 'mlcllm_quant_model')
-            mkdirs(save_quant_path)
-        if config.save.get('save_fake', False):
-            save_fake_path = os.path.join(config.save.save_path, 'fake_quant_model')
-            mkdirs(save_fake_path)
+    # Ensure only the main process creates directories
+    if int(os.environ['RANK']) == 0:
+        if 'save' in config:
+            if config.save.get('save_trans', False):
+                save_trans_path = os.path.join(config.save.save_path, 'transformed_model')
+                mkdirs(save_trans_path)
+            if config.save.get('save_trtllm', False):
+                save_trtllm_trans_path = os.path.join(
+                    config.save.save_path, 'trtllm_transformed_model'
+                )
+                mkdirs(save_trtllm_trans_path)
+                save_trtllm_engine_path = os.path.join(
+                    config.save.save_path, 'trtllm_engine'
+                )
+                mkdirs(save_trtllm_engine_path)
+            if config.save.get('save_vllm', False):
+                save_quant_path = os.path.join(config.save.save_path, 'vllm_quant_model')
+                mkdirs(save_quant_path)
+            if config.save.get('save_sgl', False):
+                save_quant_path = os.path.join(config.save.save_path, 'sgl_quant_model')
+                mkdirs(save_quant_path)
+            if config.save.get('save_autoawq', False):
+                save_quant_path = os.path.join(config.save.save_path, 'autoawq_quant_model')
+                mkdirs(save_quant_path)
+            if config.save.get('save_mlcllm', False):
+                save_quant_path = os.path.join(config.save.save_path, 'mlcllm_quant_model')
+                mkdirs(save_quant_path)
+            if config.save.get('save_fake', False):
+                save_fake_path = os.path.join(config.save.save_path, 'fake_quant_model')
+                mkdirs(save_fake_path)
+
+    # Synchronize all processes after directory creation
+    torch.distributed.barrier()
 
     main(config)
 


### PR DESCRIPTION
 When running with multiple GPUs, prevent directory creation conflicts
 by having only the main process (rank 0) create output directories.
 Other processes will wait at a barrier until directories are created.

 - Add rank check before directory creation
 - Add distributed barrier for process synchronization
 - Keep existing directory existence check for safety