### PR TITLE
[Refine] Use tokenizer.save_pretrained api instead of manual copying

### DIFF
--- a/llmc/compression/quantization/base_blockwise_quantization.py
+++ b/llmc/compression/quantization/base_blockwise_quantization.py
@@ -11,7 +11,6 @@ import torch.distributed as dist
 import torch.nn as nn
 from loguru import logger
 
-from llmc.utils import copy_files
 from llmc.utils.registry_factory import KV_REGISTRY
 
 from ..blockwise_optimization import BlockwiseOpt
@@ -910,10 +909,7 @@ class BaseBlockwiseQuantization(BlockwiseOpt):
 
     @torch.no_grad()
     def copy_tokenizer(self, path):
-        for substring in self.config.save.get(
-            'tokenizer_file_substring', ['token', 'merges', 'vocab', 'preprocessor_config', 'chat_template'] # noqa
-        ):
-            copy_files(self.config.model.path, path, substring)
+        self.model.tokenizer.save_pretrained(path)
         logger.info('copy tokenizer done --')
 
     @torch.no_grad()

--- a/llmc/compression/sparsification/base_blockwise_sparsification.py
+++ b/llmc/compression/sparsification/base_blockwise_sparsification.py
@@ -118,8 +118,7 @@ class BaseBlockwiseSparsification(BlockwiseOpt):
 
     @torch.no_grad()
     def copy_tokenizer(self, path):
-        for substring in self.config.save.get('tokenizer_file_substring', ['token']):
-            copy_files(self.config.model.path, path, substring)
+        self.model.tokenizer.save_pretrained(path)
         logger.info('copy tokenizer done --')
 
     @torch.no_grad()


### PR DESCRIPTION
# Motivation
- Using a Hugging Face model ID as the model path may trigger a tokenizer copy error.  We can use the `tokenizer.save_pretrained` api instead of manual copying.

![image](https://github.com/user-attachments/assets/a86026c1-9aba-41e8-bb9e-28f60e9dc242)
