### PR TITLE
fix: complete Falcon model support and add Pile dataset

### DIFF
--- a/llmc/data/dataset/base_dataset.py
+++ b/llmc/data/dataset/base_dataset.py
@@ -38,6 +38,7 @@ class BaseDataset(metaclass=ABCMeta):
         self.seed = calib_cfg['seed']
         self.calib_dataset_field_map = {
             'pileval': 'text',
+            'pile': 'text',
             'c4': 'text',
             'wikitext2': 'text',
             'ptb': 'sentence',
@@ -65,6 +66,10 @@ class BaseDataset(metaclass=ABCMeta):
             elif self.calib_dataset_name == 'ptb':
                 self.calib_dataset = load_dataset(
                     'ptb_text_only', 'penn_treebank', split='train'
+                )
+            elif self.calib_dataset_name == 'pile':
+                self.calib_dataset = load_dataset(
+                    'mit-han-lab/pile-val-backup', split='validation'
                 )
             elif self.calib_dataset_name == 'ultrachat':
                 self.calib_dataset = load_dataset(

--- a/llmc/data/dataset/specified_preproc.py
+++ b/llmc/data/dataset/specified_preproc.py
@@ -48,6 +48,18 @@ def c4_gptq(calib_dataset, tokenizer, n_samples, seq_len):
 
 
 @PREPROC_REGISTRY
+def pile_gptq(calib_dataset, tokenizer, n_samples, seq_len):
+    trainenc = tokenizer('\n\n'.join(calib_dataset['text'][:1000]), return_tensors='pt')
+    samples = []
+    for _ in range(n_samples):
+        i = random.randint(0, trainenc.input_ids.shape[1] - seq_len - 1)
+        j = i + seq_len
+        inp = trainenc.input_ids[:, i:j]
+        samples.append(inp)
+    return samples
+
+
+@PREPROC_REGISTRY
 def pileval_awq(calib_dataset, tokenizer, n_samples, seq_len):
     dataset = calib_dataset.shuffle(seed=42)
     samples = []

--- a/llmc/eval/eval_base.py
+++ b/llmc/eval/eval_base.py
@@ -25,6 +25,7 @@ class BaseEval:
             'wikitext2',
             'c4',
             'ptb',
+            'pile',
             'custom',
             'human_eval',
             'mme',
@@ -32,7 +33,7 @@ class BaseEval:
             'custom_gen',
             't2v',
             'i2v',
-        ], f'Not support {self.dataset} dataset now.'
+        ], f'Not support {self.eval_dataset_name} dataset now.'
         self.seq_len = self.eval_cfg.get('seq_len', None)
         self.num_samples = self.eval_cfg.get('num_samples', None)
         self.num_eval_tokens = self.eval_cfg.get('num_eval_tokens', None)
@@ -67,6 +68,10 @@ class BaseEval:
                     testdata = load_dataset(
                         'ptb_text_only', 'penn_treebank', split='test'
                     )
+                elif self.eval_dataset_name == 'pile':
+                    testdata = load_dataset(
+                        'mit-han-lab/pile-val-backup', split='validation'
+                    )
             else:
                 if self.eval_dataset_name in ['custom_gen', 'custom_ppl', 't2v', 'i2v']:
                     testdata = self.get_cutomdata(self.eval_dataset_path)
@@ -90,6 +95,10 @@ class BaseEval:
             elif self.eval_dataset_name == 'ptb':
                 testenc = self.tokenizer(
                     ' '.join(testdata['sentence']), return_tensors='pt'
+                )
+            elif self.eval_dataset_name == 'pile':
+                testenc = self.tokenizer(
+                    '\n\n'.join(testdata['text'][:1000]), return_tensors='pt'
                 )
             elif self.eval_dataset_name == 'custom_ppl':
                 testenc = self.tokenizer(

--- a/llmc/models/falcon.py
+++ b/llmc/models/falcon.py
@@ -8,12 +8,15 @@ class Falcon(BaseModel):
     def __init__(self, config, device_map=None, use_cache=False):
         super().__init__(config, device_map, use_cache)
 
+    def _is_new_decoder_architecture(self):
+        return getattr(self.model_config, 'new_decoder_architecture', False)
+
     def find_blocks(self):
         self.blocks = self.model.transformer.h
 
     def find_embed_layers(self):
         self.word_embeddings = self.model.transformer.word_embeddings
-        self.rotary_emb = self.model.model.rotary_emb
+        self.rotary_emb = self.model.transformer.rotary_emb
 
     def find_block_name(self):
         self.block_name_prefix = 'model.transformer.h'
@@ -25,30 +28,31 @@ class Falcon(BaseModel):
         return [self.rotary_emb]
 
     def get_layers_except_blocks(self):
-        return [self.word_embeddings, self.rotary_emb, self.model.transformer.ln_f]
+        return [self.word_embeddings, self.rotary_emb, self.model.transformer.ln_f,
+                self.model.lm_head]
+
+    def skip_layer_name(self):
+        return ['lm_head']
 
     def has_bias(self):
-        return False
+        return getattr(self.model_config, 'bias', False)
 
     def get_layernorms_in_block(self, block):
-        if block.config.architectures[0] == 'RWForCausalLM':
-            new_decoder_architecture = False
-        elif block.config.architectures[0] == 'FalconForCausalLM':
-            new_decoder_architecture = True
-        if new_decoder_architecture:
+        if self._is_new_decoder_architecture():
             return {'ln_attn': block.ln_attn, 'ln_mlp': block.ln_mlp}
         else:
-            if block.config.parallel_attn:
+            if getattr(block.config, 'parallel_attn', False):
                 return {'input_layernorm': block.input_layernorm}
             else:
-                return {'post_attention_layernorm': block.post_attention_layernorm}
+                return {
+                    'input_layernorm': block.input_layernorm,
+                    'post_attention_layernorm': block.post_attention_layernorm,
+                }
 
     def get_subsets_in_block(self, block):
-        if block.config.architectures[0] == 'RWForCausalLM':
-            new_decoder_architecture = False
-        elif block.config.architectures[0] == 'FalconForCausalLM':
-            new_decoder_architecture = True
-        if new_decoder_architecture:
+        new_arch = self._is_new_decoder_architecture()
+
+        if new_arch:
             subset1 = {
                 'layers': {
                     'self_attention.query_key_value': (
@@ -79,7 +83,7 @@ class Falcon(BaseModel):
                 'inspect': block.self_attention.query_key_value,
                 'has_kwargs': False,
             }
-            if block.config.parallel_attn:
+            if getattr(block.config, 'parallel_attn', False):
                 subset3 = {
                     'layers': {'mlp.dense_h_to_4h': block.mlp.dense_h_to_4h},
                     'prev_op': [block.input_layernorm],


### PR DESCRIPTION
## Summary

- **Falcon model**: The existing `Falcon` class in `llmc/models/falcon.py` was non-functional due to several issues. This PR fixes them so Falcon models (both old `RWForCausalLM` and new `FalconForCausalLM` architectures) work correctly with all quantization algorithms.
- **Pile dataset**: Adds `pile` as a supported calibration and evaluation dataset, loading from `mit-han-lab/pile-val-backup`. Several quantization papers (SmoothQuant, LLM.int8()) use Pile for calibration, but it was not available as a dataset option.

## Falcon Fixes

| Issue | Before | After |
|-------|--------|-------|
| `skip_layer_name()` | Missing (abstract) — **caused instantiation failure** | Returns `['lm_head']` |
| `find_embed_layers()` | `self.model.model.rotary_emb` (wrong path) | `self.model.transformer.rotary_emb` |
| `get_layers_except_blocks()` | Missing `lm_head` | Includes `lm_head` |
| `has_bias()` | Hardcoded `False` | Reads from `model_config.bias` |
| Architecture detection | `block.config.architectures[0]` string comparison (fragile, could raise on unknown arch) | `model_config.new_decoder_architecture` with `getattr` fallback |
| Old-arch layernorms (non-parallel) | Only returned `post_attention_layernorm` | Returns both `input_layernorm` and `post_attention_layernorm` |

## Pile Dataset

- `base_dataset.py`: Added `'pile'` to field map and `build_calib_dataset()` (loads `mit-han-lab/pile-val-backup` validation split)
- `specified_preproc.py`: Added `pile_gptq` preprocessor (same pattern as `wikitext2_gptq`)
- `eval_base.py`: Added `'pile'` to supported dataset list, download logic, and tokenization
- Also fixed a minor bug in `eval_base.py` error message: `self.dataset` → `self.eval_dataset_name`

## Test plan

- [ ] Verify `tiiuae/falcon-7b` (old arch, `parallel_attn=True`) loads and quantizes with RTN/GPTQ
- [ ] Verify `tiiuae/falcon-40b` (new arch, `new_decoder_architecture=True`) loads and quantizes
- [ ] Verify `pile` calibration dataset loads and preprocesses correctly
- [ ] Verify `pile` evaluation dataset loads and computes perplexity

Made with [Cursor](https://cursor.com)