### PR TITLE
debug vllm per-block

### DIFF
--- a/llmc/utils/export_vllm.py
+++ b/llmc/utils/export_vllm.py
@@ -31,7 +31,8 @@ def update_vllm_quant_config(
             with open(config_file, 'w') as file:
                 json.dump(config_vllm, file, indent=4)
             return
-        elif config.quant.weight.get('granularity', 'per_block'):
+        # elif config.quant.weight.get('granularity', 'per_block'):
+        elif config.quant.weight.get('granularity') == 'per_block':
             quant_config = {
                 'activation_scheme': 'dynamic',
                 'fmt': 'e4m3',


### PR DESCRIPTION
debug: original judge will get into per-block when per-channel or per-token quant when export vllm